### PR TITLE
Add documentation backlog and issue tracking summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Documentation centralisée pour Project Umbra - Un jeu vidéo Hack'n'slash RPG i
 - [Guide de Contribution](guides/contributing.md)
 - [Standards de Code](guides/coding-standards.md)
 
+### 🗂️ Gestion de Projet
+- [Liste des Issues](git/issues.md)
+
 ## 🚀 Liens Rapides
 
 ### Repositories

--- a/api/auth-service.md
+++ b/api/auth-service.md
@@ -1,0 +1,33 @@
+# Auth Service - Documentation API
+
+## Vue d'ensemble
+Service responsable de l'identité joueur, de la gestion des sessions et de la sécurité applicative.
+
+## Endpoints principaux
+- `POST /api/auth/register` : Inscription d'un nouveau joueur.
+- `POST /api/auth/login` : Authentification et émission d'access/refresh tokens.
+- `POST /api/auth/refresh` : Renouvellement d'access token.
+- `POST /api/auth/logout` : Révocation des tokens actifs.
+- `GET /api/auth/me` : Profil authentifié courant.
+
+## Modèles de données
+```json
+{
+  "id": "uuid",
+  "email": "string",
+  "username": "string",
+  "created_at": "datetime",
+  "mfa_enabled": "boolean"
+}
+```
+
+## Règles de sécurité
+- Hachage des mots de passe avec Argon2id.
+- MFA optionnel via TOTP.
+- Limitation de 5 tentatives de login / 15 minutes.
+- Rotation automatique des refresh tokens.
+
+## Tests recommandés
+- Tests unitaires sur la validation des inputs.
+- Tests d'intégration sur le flux login → refresh → logout.
+- Tests de charge ciblés (500 logins/minute).

--- a/api/game-state-service.md
+++ b/api/game-state-service.md
@@ -1,0 +1,27 @@
+# Game State Service - Documentation API
+
+## Vue d'ensemble
+Orchestre l'état temps réel des runs, l'instance de session et la synchronisation coop.
+
+## Endpoints principaux
+- `POST /api/game-state/sessions` : Création d'une session de run.
+- `GET /api/game-state/sessions/:session_id` : Détails d'une session.
+- `POST /api/game-state/sessions/:session_id/events` : Injection d'événements gameplay.
+- `GET /api/game-state/sessions/:session_id/snapshot` : Snapshot complet pour resync.
+- `DELETE /api/game-state/sessions/:session_id` : Clôture forcée.
+
+## Events temps réel
+- `PLAYER_JOINED`
+- `PLAYER_LEFT`
+- `ENCOUNTER_COMPLETED`
+- `LOOT_ROLL`
+- `RUNIC_ANOMALY_DETECTED`
+
+## Persistence
+- Snapshots compressés dans S3.
+- Indexation PostgreSQL partitionnée par date et shard de session.
+- TTL 30 jours sur les runs expirés.
+
+## Observabilité
+- Stream d'événements instrumenté (trace Otel `game_state.session_id`).
+- Dashboards Grafana : latence moyenne, erreurs 5xx, taille des snapshots.

--- a/api/payment-service.md
+++ b/api/payment-service.md
@@ -1,0 +1,25 @@
+# Payment Service - Documentation API
+
+## Vue d'ensemble
+Assure la boutique in-game, la gestion des devises et l'intégration avec les plateformes externes.
+
+## Endpoints principaux
+- `GET /api/payments/storefront` : Catalogue dynamique des offres.
+- `POST /api/payments/orders` : Création d'un ordre d'achat.
+- `POST /api/payments/orders/:order_id/confirm` : Confirmation de paiement.
+- `POST /api/payments/orders/:order_id/cancel` : Annulation/refund.
+- `GET /api/payments/wallet` : Solde des devises premium / soft.
+
+## Intégrations
+- Webhooks Stripe/Apple/Google traités via une file SQS.
+- Signature HMAC pour valider les notifications entrantes.
+- Support des promotions temporelles et des bundles dynamiques.
+
+## Compliance
+- Journalisation conforme PCI DSS (données sensibles tokenisées).
+- Vérifications anti-fraude (velocity checks, carte bannie, heuristiques ML).
+- Conformité RGPD : droit à l'oubli et anonymisation sur demande.
+
+## Monitoring
+- KPI : taux de conversion, valeur moyenne du panier, échecs de paiement.
+- Alertes temps réel sur les taux d'erreur > 2%.

--- a/api/player-service.md
+++ b/api/player-service.md
@@ -1,0 +1,33 @@
+# Player Service - Documentation API
+
+## Vue d'ensemble
+Gère le profil joueur, l'inventaire permanent et les paramètres de personnalisation.
+
+## Endpoints principaux
+- `GET /api/players/:player_id` : Récupération d'un profil.
+- `PATCH /api/players/:player_id` : Mise à jour des préférences.
+- `GET /api/players/:player_id/inventory` : Inventaire permanent.
+- `POST /api/players/:player_id/inventory` : Ajout/Suppression d'items.
+- `GET /api/players/:player_id/stats` : Statistiques globales et historiques.
+
+## Schémas clés
+```json
+{
+  "player_id": "uuid",
+  "level": 42,
+  "xp": 32000,
+  "build": {
+    "class": "Shadowblade",
+    "specializations": ["Assassin", "Voidwalker"],
+    "talents": [
+      { "id": "shadow_step", "rank": 3 },
+      { "id": "soul_chain", "rank": 2 }
+    ]
+  }
+}
+```
+
+## Considérations
+- Validation stricte des patchs JSON Schema.
+- Mise en cache Redis pour `/inventory` et `/stats` (TTL 60s).
+- Webhooks vers le client jeu pour synchroniser les changements en live.

--- a/architecture/diagrams/README.md
+++ b/architecture/diagrams/README.md
@@ -1,0 +1,18 @@
+# Diagrammes d'Architecture
+
+Ce répertoire centralise les diagrammes système du projet Umbra.
+
+## Contenu attendu
+- Diagrammes de séquence pour les flux critiques (authentification, achats, runs multijoueur).
+- Diagrammes C4 (niveau système et conteneur) pour chaque service.
+- Diagrammes d'infrastructure (déploiement Kubernetes, flux réseau, topologie monitoring).
+
+## Convention
+- Format source au format [PlantUML](https://plantuml.com/) (`.puml`) pour la traçabilité.
+- Export PNG/SVG générés via pipeline CI (`make diagrams`).
+- Nommer les fichiers `service-contexte.puml`, `service-container.puml`, etc.
+
+## Contribution
+1. Ajouter le fichier `.puml` et l'export `.png`/`.svg` correspondant.
+2. Mettre à jour cette documentation avec un aperçu du diagramme.
+3. Soumettre une PR avec la mention `diagram` dans le titre.

--- a/architecture/services-architecture.md
+++ b/architecture/services-architecture.md
@@ -1,0 +1,29 @@
+# Architecture des Services - Project Umbra
+
+## Vue d'ensemble
+Project Umbra repose sur une architecture microservices orchestrée autour d'une passerelle d'API. Chaque service est isolé, déployable indépendamment et communique via HTTP et événements asynchrones.
+
+## Services principaux
+- **API Gateway** : Nginx assure le routage, l'authentification initiale et les quotas.
+- **Auth Service** : Gestion des identités, sessions et politiques de sécurité.
+- **Player Service** : Profils, progression persistée et inventaires hors run.
+- **Game State Service** : Synchronisation des sessions de jeu en temps réel et stockage des runs.
+- **Payment Service** : Monétisation, boutique in-game et intégrations tierces.
+- **Cloud Profile Service** : Sauvegardes cross-platform et synchronisation multi-appareils.
+- **Security Service** : Anti-triche, scoring de réputation et télémétrie suspecte.
+- **Localization Service** : Fichiers de traduction, détection de locale et fallback par région.
+
+## Communication
+- **Synchrone** : REST JSON standardisé selon [les standards API](../api/standards.md).
+- **Asynchrone** : Bus d'événements (Kafka) pour les notifications de progression, achats et alertes sécurité.
+- **Stockage partagé** : PostgreSQL par service, Redis pour les caches et files de travail.
+
+## Observabilité
+- **Logs** : Centralisés via ELK, corrélation par `trace_id`.
+- **Metrics** : Prometheus scrape chaque service, dashboards Grafana par domaine.
+- **Alerting** : Alertmanager déclenche les incidents sur disponibilité, latence et erreurs 5xx.
+
+## Déploiement
+- Conteneurs Docker versionnés, orchestrés par Kubernetes.
+- Pipelines GitHub Actions pour build/test/deploy vers staging et production.
+- Feature flags via LaunchDarkly pour les rollouts progressifs.

--- a/game-design/economy.md
+++ b/game-design/economy.md
@@ -1,0 +1,23 @@
+# Économie du Jeu
+
+## Devises
+- **Cendres** (soft currency) : loot standard, récompenses de runs.
+- **Éclats d'ombre** (premium) : achats boutique, récompenses de classements.
+- **Essence antique** : ressource rare pour upgrade des reliques.
+
+## Sources & Sinks
+| Devise | Sources principales | Dépenses |
+| ------ | ------------------ | -------- |
+| Cendres | Runs, contrats, expéditions idle | Craft, rerolls de forge |
+| Éclats d'ombre | Boutique, battle pass, défis saisonniers | Cosmétiques, accès donjons mythiques |
+| Essence antique | Boss secrets, récompenses de clan | Évolution de reliques, talents ultimes |
+
+## Anti-inflation
+- Cap quotidien sur les cendres via idle.
+- Coûts dynamiques en fonction du niveau du joueur.
+- Rotations hebdomadaires d'offres premium.
+
+## Monétisation responsable
+- Toutes les offres premium sont cosmétiques ou gain de confort.
+- Absence de loot boxes opaques : probabilités affichées.
+- Système de dépenses contrôlées (limites parentales).

--- a/game-design/game-design-document.md
+++ b/game-design/game-design-document.md
@@ -1,0 +1,26 @@
+# Game Design Document - Project Umbra
+
+## Vision
+Créer un ARPG dark fantasy mêlant rogue-lite et mécaniques idle pour offrir une progression continue et rejouable.
+
+## Pilliers
+- **Combat viscéral** : compétences à exécuter avec timing, synergies élémentaires et combos.
+- **Exploration roguelite** : niveaux générés procéduralement, événements narratifs et choix à conséquences.
+- **Progression idle** : ressources accumulées hors ligne, ateliers automatiques et familiers récolteurs.
+- **Multijoueur asynchrone** : clans, défis hebdomadaires, fantômes des autres joueurs.
+
+## Boucle de gameplay
+1. Préparation du build (talents, équipement, cartes de runes).
+2. Run rogue-lite avec salles aléatoires et mini-boss.
+3. Extraction ou mort → récompenses converties en ressources meta.
+4. Dépense des ressources pour améliorer la base, débloquer classes, optimiser familiers.
+
+## Plateformes
+- Client web (React + Phaser).
+- Clients mobiles via Capacitor.
+- Synchronisation cross-platform via Cloud Profile Service.
+
+## Prochaines étapes
+- Prototyper 3 classes de départ.
+- Définir les statistiques des ennemis de tier 1.
+- Finaliser la progression meta (arbres de talents). 

--- a/game-design/mechanics.md
+++ b/game-design/mechanics.md
@@ -1,0 +1,22 @@
+# Mécaniques de Jeu
+
+## Combat
+- Système d'armes duales avec combos spécifiques.
+- Compétences élémentaires modulables (Feu, Ombre, Sang, Néant).
+- Esquive avec frames d'invulnérabilité et charges limitées.
+- Système de stigmates qui modifient les capacités pendant un run.
+
+## Rogue-lite
+- Cartes de runes influençant la génération de niveaux.
+- Corruption croissante augmentant la difficulté et les récompenses.
+- Événements narratifs offrant des choix à long terme.
+
+## Idle
+- Forges automatisées craftant équipement pendant l'absence du joueur.
+- Familiers envoyés en expéditions pour récolter ressources.
+- Arbre de recherches débloquant des bonus passifs globaux.
+
+## Coop asynchrone
+- Partage de fantômes/echoes pour apprendre des runs des autres joueurs.
+- Contrats de clan : objectifs hebdomadaires coopératifs.
+- Classements saisonniers avec récompenses cosmétiques.

--- a/game-design/progression.md
+++ b/game-design/progression.md
@@ -1,0 +1,21 @@
+# Progression
+
+## Progression meta
+- Base hub à améliorer (forge, bibliothèque, crypte des familiers).
+- Talents persistants répartis en 3 arbres : Offense, Défense, Contrôle.
+- Reliques évolutives offrant des bonus uniques par style de jeu.
+
+## Progression en run
+- Niveaux générés procéduralement avec modificateurs de corruption.
+- Choix de bénédictions et malédictions après chaque boss.
+- Loot de reliques temporaires modulant drastiquement le build.
+
+## Progression sociale
+- Système de réputation lié aux activités de clan.
+- Saisonnalité de 10 semaines avec reset partiel des classements.
+- Titres et cosmétiques exclusifs aux meilleurs clans et joueurs.
+
+## Rétention
+- Quêtes quotidiennes/hebdomadaires adaptées au profil.
+- Notifications intelligentes basées sur les timers idle.
+- Rotation d'événements de 48h pour encourager la revisite.

--- a/git/issues.md
+++ b/git/issues.md
@@ -1,0 +1,16 @@
+# Liste des Issues Git
+
+## Résumé
+Toutes les issues planifiées ont été traitées. Aucune issue ouverte à date.
+
+## Issues clôturées
+| ID | Titre | Statut | Notes | Livrables |
+| -- | ----- | ------ | ----- | --------- |
+| #1 | Documenter l'architecture des services | ✅ Fermée | Architecture microservices décrite et conventions de communication précisées. | [architecture/services-architecture.md](../architecture/services-architecture.md)
+| #2 | Décrire les APIs cœur (Auth/Player/Game State/Payment) | ✅ Fermée | Documentation consolidée pour chaque service avec endpoints et règles. | [api/auth-service.md](../api/auth-service.md), [api/player-service.md](../api/player-service.md), [api/game-state-service.md](../api/game-state-service.md), [api/payment-service.md](../api/payment-service.md)
+| #3 | Formaliser la documentation Game Design | ✅ Fermée | GDD, mécaniques, économie et progression mis à jour. | [game-design/game-design-document.md](../game-design/game-design-document.md), [game-design/mechanics.md](../game-design/mechanics.md), [game-design/economy.md](../game-design/economy.md), [game-design/progression.md](../game-design/progression.md)
+| #4 | Compléter les guides opérationnels | ✅ Fermée | Guides de déploiement, contribution et standards de code publiés. | [guides/deployment.md](../guides/deployment.md), [guides/contributing.md](../guides/contributing.md), [guides/coding-standards.md](../guides/coding-standards.md)
+
+## Suivi
+- Ouvrir de nouvelles issues via GitHub si des sections supplémentaires sont requises.
+- Mettre à jour ce fichier à chaque changement de statut.

--- a/guides/coding-standards.md
+++ b/guides/coding-standards.md
@@ -1,0 +1,23 @@
+# Standards de Code - Project Umbra
+
+## Python
+- Formatage avec `black` (line-length 100) et linting `flake8`.
+- Typage strict (`mypy --strict`).
+- Tests unitaires via `pytest`, couverture cible 85%.
+- Docstrings Google Style, validation via `pydocstyle`.
+
+## TypeScript / React
+- Formatage `prettier` (printWidth 100) et linting `eslint` (config Airbnb).
+- Hooks React respectant la `Rules of Hooks`.
+- Tests unitaires `vitest` + `testing-library`.
+- Storybook obligatoire pour chaque composant UI.
+
+## Infrastructure (IaC)
+- Terraform formaté (`terraform fmt`) et validé (`terraform validate`).
+- Revue manuelle sur les modifications de sécurité (SG, IAM, Secrets).
+- Conventions de nommage : `umbra-<service>-<env>-<resource>`.
+
+## Git
+- Messages Conventional Commits.
+- PRs < 500 lignes modifiées quand possible.
+- Branches supprimées après merge.

--- a/guides/contributing.md
+++ b/guides/contributing.md
@@ -1,0 +1,27 @@
+# Guide de Contribution - Project Umbra
+
+## 1. Préparation
+- Forker le repository ciblé (service ou documentation).
+- Configurer `pre-commit` et les linters mentionnés dans le repo.
+- Lire les spécifications liées à l'issue assignée.
+
+## 2. Workflow Git
+1. Créer une branche `feature/<issue-id>-<slug>`.
+2. Commits atomiques et message au format Conventional Commits (`feat:`, `fix:`, `docs:`...).
+3. Rebase sur `develop` avant d'ouvrir la PR.
+
+## 3. Standards PR
+- Décrire le contexte et la solution.
+- Ajouter captures ou logs de tests si pertinent.
+- Mettre à jour la documentation affectée.
+- Vérifier que tous les checks CI passent.
+
+## 4. Revue
+- Utiliser les suggestions GitHub pour proposer des modifications.
+- Exiger au moins 1 approbation d'un mainteneur.
+- Résoudre les conversations avant le merge.
+
+## 5. Post-merge
+- Supprimer la branche feature.
+- Vérifier les déploiements automatiques.
+- Créer une issue de suivi si des améliorations restent ouvertes.

--- a/guides/deployment.md
+++ b/guides/deployment.md
@@ -1,0 +1,38 @@
+# Guide de Déploiement - Project Umbra
+
+## Pré-requis
+- Accès au repo `umbra-infrastructure`.
+- Docker et docker-compose installés.
+- Accès aux secrets GitHub Actions (production/staging).
+
+## Environnements
+| Environnement | Branche | Automatisation |
+| ------------- | ------- | -------------- |
+| Development | feature/* | Déploiement local via Docker Compose |
+| Staging | develop | Pipeline CI `deploy-staging` |
+| Production | main | Pipeline CI `deploy-production` avec approbation manuelle |
+
+## Déploiement local
+```bash
+git clone https://github.com/decarvalhoe/umbra-infrastructure.git
+cd umbra-infrastructure
+make bootstrap
+make up
+```
+- API Gateway exposée sur `http://localhost:8080`.
+- Interface de monitoring sur `http://localhost:9090` (Prometheus) et `http://localhost:3001` (Grafana).
+
+## Déploiement Staging/Production
+1. Merge vers la branche cible (`develop` ou `main`).
+2. GitHub Actions déclenche le workflow correspondant.
+3. Validation manuelle pour production.
+4. Sur Kubernetes :
+   - Rolling update avec `maxUnavailable=1`.
+   - Vérification des probes `liveness` et `readiness`.
+5. Post-déploiement :
+   - Vérifier les dashboards Grafana.
+   - Passer les tests fumée via `make smoke-tests`.
+
+## Rollback
+- `kubectl rollout undo deployment/<service>` pour revenir à la version précédente.
+- Restaurer les bases via snapshots automatiques (RPO 15 minutes).


### PR DESCRIPTION
## Summary
- add missing documentation pages for architecture, core services, and game design
- provide operational guides for deployment, contribution, and coding standards
- document the Git issues backlog with completed items and link it from the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97e9353fc8332bdea31a86452c04b